### PR TITLE
Update README.md with venv instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,28 @@
 # ENUCC Tutorials
+To deploy changes to the guide you will need to use the python library mkdocs and deploy from a cloned repository in a linux environment.
+You can make and commit edits to the pages in /docs/ on the browser version but you will need to redeploy for the changes to appear on the documentation GUI.
 
+# Deploy with mkdocs in a virtual environment (venv)
+
+Clone the repository and then open it
+```
+git clone git@github.com:SCEBE-Technicians/enucc-tutorials.git
+cd enucc-tutorials
+```
+Create and activate the venv
+```
+python3 -m venv venv
+source venv/bin/activate
+```
+Install MkDocs and deploy changes
+```
+pip install mkdocs-material
+source venv/bin/activate
+mkdocs gh-deploy
+deactivate     # deactivate the venv
+```
+
+# Or using docker:
 Start docker container with
 
 ```


### PR DESCRIPTION
Update readme to include venv instructions and additional context for editing and deploying edits to the Enucc tutorial site.